### PR TITLE
refactor: move varPhiBeta magic constants to config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -63,3 +63,25 @@ export class Config {
     }
 
 }
+
+/**
+ * Maximum fusion ratio cap (q*) used in the Gluon protocol's fusionRatio
+ * calculation. When the computed ratio exceeds this value it is clamped here.
+ * Expressed in nano-ERG units (1e9 base).
+ */
+export const GLUON_QSTAR: bigint = BigInt(660000000);
+
+/**
+ * Base (minimum) fee coefficient (φ₀) in the varPhiBeta fee-curve formula.
+ * This is the floor value of the dynamic fee regardless of trade volume.
+ * Expressed in nano-ERG units (1e9 base).
+ */
+export const GLUON_PHI0: bigint = BigInt(5000000);
+
+/**
+ * Volume-scaled fee coefficient (φ₁) in the varPhiBeta fee-curve formula.
+ * Multiplied by the net directional volume and divided by fissioned ERG to
+ * produce the variable portion of the protocol fee.
+ * Expressed in nano-ERG units (1e9 base).
+ */
+export const GLUON_PHI1: bigint = BigInt(500000000);

--- a/src/gluonBox.ts
+++ b/src/gluonBox.ts
@@ -2,11 +2,12 @@ import {ErgoTree} from "@nautilus-js/eip12-types";
 import {Serializer} from "./serializer";
 import {BUCKET_LEN, NEUTRON_ID, PROTON_ID} from "./consts";
 import {PegOracleBox} from "./pegOracleBox";
+import {GLUON_QSTAR, GLUON_PHI0, GLUON_PHI1} from "./config";
 
 export class GluonBox {
     boxJs: any;
     serializer: Serializer;
-    qstar = BigInt(660000000)
+    qstar = GLUON_QSTAR
 
     constructor(box: any) {
         this.boxJs = box;
@@ -160,8 +161,8 @@ export class GluonBox {
      * @param volumeToMinus volume
      */
     varPhiBeta(rErg: bigint, volumeToBeNegate: number[], volumeToMinus: number[]): bigint {
-        const phi0 = BigInt(5000000)
-        const phi1 = BigInt(500000000)
+        const phi0 = GLUON_PHI0
+        const phi1 = GLUON_PHI1
         const sumVolumeToBeNegate = volumeToBeNegate.reduce((acc, x) => acc + BigInt(x), BigInt(0))
         const sumVolumeToMinus = volumeToMinus.reduce((acc, x) => acc + BigInt(x), BigInt(0))
         const volume = sumVolumeToBeNegate < sumVolumeToMinus ? BigInt(0) : sumVolumeToBeNegate - sumVolumeToMinus


### PR DESCRIPTION
### Addressed Issues:
Fixes https://github.com/StabilityNexus/Gluon-Ergo-SDK/issues/18?reload=1

### Screenshots/Recordings:
No UI changes — pure refactor. Not applicable.

### Additional Notes:
Moves the three hardcoded magic constants from gluonBox.ts into config.ts as named exported constants, as requested by @Bruno.

- GLUON_QSTAR (660000000) — fusion ratio cap
- GLUON_PHI0 (5000000) — base fee floor in varPhiBeta
- GLUON_PHI1 (500000000) — volume-scaled fee coefficient in varPhiBeta

Zero logic changes. Build passes with no errors.

### AI Usage Disclosure:
- [x] This PR contains AI-generated code. I have read the AI Usage Policy and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude (Anthropic), Perplexity AI

## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the Discord server and I will share a link to this PR with the project maintainers there
- [x] I have read the Contribution Guidelines
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable Gluon protocol parameters for maximum fusion ratio cap and fee-curve coefficients, enabling centralized management of protocol settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->